### PR TITLE
add dockerfile for proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM --platform=$BUILDPLATFORM python:3.9-slim
+
+WORKDIR /app
+
+ARG TARGETARCH
+
+RUN apt-get update && apt-get install -y curl && \
+    if [ "$TARGETARCH" = "arm64" ]; then \
+        curl -O -L https://github.com/okareo-ai/okareo-cli/releases/latest/download/okareo_linux_arm64.tar.gz && \
+        tar -xvf okareo_linux_arm64.tar.gz && \
+        rm okareo_linux_arm64.tar.gz; \
+    else \
+        curl -O -L https://github.com/okareo-ai/okareo-cli/releases/latest/download/okareo_linux_amd64.tar.gz && \
+        tar -xvf okareo_linux_amd64.tar.gz && \
+        rm okareo_linux_amd64.tar.gz; \
+    fi && \
+    chmod +x okareo && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/app:${PATH}"
+EXPOSE 4000
+
+CMD ["okareo", "proxy"]


### PR DESCRIPTION
Setup .env file with the necessary env vars for proxy
First build:
`docker build -t okareo-proxy .`
Then run it:
`docker run -it -p 4000:4000 --env-file .env okareo-proxy`
it may take a minute or two to get started. Once it outputs, starting proxy on 4000, it is ready to be called upon